### PR TITLE
Categorize esr68 trees

### DIFF
--- a/frontend/src/App/TreeStatus/View.elm
+++ b/frontend/src/App/TreeStatus/View.elm
@@ -368,6 +368,7 @@ categorizeTrees trees =
                     List.member tree.name
                         [ "mozilla-beta"
                         , "mozilla-release"
+                        , "mozilla-esr68"
                         , "mozilla-esr60"
                         , "mozilla-esr52"
                         ]
@@ -394,6 +395,7 @@ categorizeTrees trees =
                         , "comm-beta-seamonkey"
                         , "comm-release-thunderbird"
                         , "comm-release-seamonkey"
+                        , "comm-esr68-thunderbird"
                         , "comm-esr60-thunderbird"
                         , "comm-esr60-seamonkey"
                         , "comm-esr52-thunderbird"


### PR DESCRIPTION
Brings back https://github.com/mozilla/release-services/pull/2271 from the old repo.