### PR TITLE
Expose input validation errors as 400

### DIFF
--- a/api/src/treestatus_api/__init__.py
+++ b/api/src/treestatus_api/__init__.py
@@ -6,11 +6,16 @@
 import os
 
 import taskcluster
+from connexion.exceptions import ExtraParameterProblem
 
 import treestatus_api.config
 import treestatus_api.lib.flask
 import treestatus_api.models  # noqa
 import treestatus_api.view
+
+
+def handle_bad_request(exception):
+    return "Extra paramter passed", 400
 
 
 def create_app(config=None):
@@ -32,5 +37,6 @@ def create_app(config=None):
     app.add_url_rule("/static/<path:filename>", "static_handler", treestatus_api.view.static_handler)
 
     app.api.register(os.path.join(os.path.dirname(__file__), "api.yml"))
+    app.register_error_handler(ExtraParameterProblem, handle_bad_request)
 
     return app


### PR DESCRIPTION
Connexion by default treats input validation as 500, what generates a
lot of errors.

This will convert 500s into 400s inly in case when an extra (unknown,
misspelled) paramter passed.